### PR TITLE
Checks if payment is None before getting status

### DIFF
--- a/backend/apps/root/models.py
+++ b/backend/apps/root/models.py
@@ -222,7 +222,11 @@ class TicketedEvent(DBModel):
 
     @property
     def has_pending_checkout(self):
-        return self.payments.last().status in [None, "PENDING", "CANCELLED", "FAILURE"]
+        last_payment = self.payments.last()
+        if last_payment is None:
+            return True
+
+        return last_payment.status in [None, "PENDING", "CANCELLED", "FAILURE"]
 
 
 class RedemptionAccessKey(DBModel):


### PR DESCRIPTION
Closes #58 

-----------

Payment is still only created on proceed to checkout, but now handles ticketed events with no issued payments properly.
