### PR TITLE
Fixes security hole in editing capacity after payment was issued

### DIFF
--- a/backend/apps/root/forms.py
+++ b/backend/apps/root/forms.py
@@ -58,21 +58,33 @@ class TicketedEventForm(forms.ModelForm):
             ),
         }
 
+    def can_edit_capacity(self) -> bool:
+        if self.instance is None:
+            return True
+
+        return not (
+            pricing_service.get_in_progress_payment(self.instance)
+            or pricing_service.get_effective_payments(self.instance.payments)
+        )
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        instance = getattr(self, "instance", None)
-        if not instance:
-            return
-
-        if (
-            pricing_service.get_in_progress_payment(instance)
-            or pricing_service.get_effective_payments(instance.payments)
-        ):
+        if not self.can_edit_capacity():
             self.fields["capacity"].disabled = True
 
     def save(self, commit: bool = ...) -> TicketedEvent:
         """Sets TicketedEvent price after save"""
+        if (
+            (not self.can_edit_capacity())
+            and (self.instance.capacity != self.cleaned_data["capacity"])
+        ):
+            # not using field has_changed here since it can lead to a
+            # security failure as it checks if the field is disabled.
+
+            # this will never happend since capacity field is disabled, unless the user tries to hack the form
+            raise RuntimeError("Cannot change capacity")
+
         obj = super().save(commit)
 
         if "capacity" in self.changed_data:


### PR DESCRIPTION
**Problem:**
The protection was being made by disabling capacity field. But user
could disable it via HTML and edit it still.

**Solution:**
Now checks if capacity can be edited also before saving the instance.