### PR TITLE
Return full URL for team image

### DIFF
--- a/backend/apps/api_checkoutportal/serializers.py
+++ b/backend/apps/api_checkoutportal/serializers.py
@@ -9,9 +9,19 @@ class TeamSerializer(serializers.ModelSerializer):
     Team serializer
     """
 
+    image = serializers.SerializerMethodField()
+
     class Meta:
         model = Team
         fields = ["name", "image"]
+
+    def get_image(self, obj):
+        request = self.context.get("request")
+        if obj.image:
+            image_url = obj.image.url
+            return request.build_absolute_uri(image_url)
+        else:
+            return None
 
 
 class EventSerializer(serializers.ModelSerializer):

--- a/backend/apps/api_checkoutportal/views.py
+++ b/backend/apps/api_checkoutportal/views.py
@@ -39,7 +39,9 @@ class CheckoutPortalRetrieve(EventMixin, APIView):
         """
         Retrieve serialized Event
         """
-        serialized_data = serializers.EventSerializer(self.event).data
+        serialized_data = serializers.EventSerializer(
+            self.event, context={"request": request}
+        ).data
         return Response(serialized_data)
 
 


### PR DESCRIPTION
This PR changes the event portal API request to return the full URL for the team image.