### PR TITLE
Handle scanner background color in theme

### DIFF
--- a/backend/static/socialpass-theme/binance-theme.css
+++ b/backend/static/socialpass-theme/binance-theme.css
@@ -327,3 +327,12 @@
 
     --switch-checked-bg-image: var(--switch-svg-dark);
 }
+
+/**
+ * Scanner specific styles
+ */
+
+.socialpass-scanner .main-bg {
+    color: var(--white-color);
+    background-color: var(--darkgray-color);
+}

--- a/backend/static/socialpass-theme/socialpass-theme.css
+++ b/backend/static/socialpass-theme/socialpass-theme.css
@@ -326,3 +326,16 @@
 :root {
     --sticky-alerts-width: 34rem;
 }
+
+/**
+ * Scanner specific styles
+ */
+
+.socialpass-scanner .main-bg {
+    color: var(--text-color-on-primary-color-bg);
+    background-color: var(--primary-color);
+}
+
+.socialpass-scanner.dark-mode .main-bg {
+    background-color: hsl(var(--primary-color-hue), 40%, 15%);
+}


### PR DESCRIPTION
This PR handles the background color theming for the scanner app, especially when it comes to the Binance white-labeling.

In order for this to work, the `<html>` element in the scanner app must be give the class `.socialpass-scanner` for CSS name-spacing. After that, the main background container must be given the `.main-bg` class.