### PR TITLE
Close FSM State Transition Bug on Event Form

### DIFF
--- a/backend/apps/dashboard/forms.py
+++ b/backend/apps/dashboard/forms.py
@@ -138,15 +138,24 @@ class EventDraftForm(EventForm):
         if ready_for_checkout:
             self.check_required_fields(data=data)
 
+    def save_state_transition(self, instance):
+        """
+        method for saving state transition
+        """
         # form is OK, handle state transitions
         # Only call state transition if in expected state
         # Note: No need to save, as form will call save method later
-        if ready_for_checkout:
-            if self.instance.state != Event.StateEnum.PENDING_CHECKOUT.value:
-                self.instance.transition_pending_checkout()
+        if self.cleaned_data.get("ready_for_checkout"):
+            if instance.state != Event.StateEnum.PENDING_CHECKOUT.value:
+                instance.transition_pending_checkout()
         else:
-            if self.instance.state != Event.StateEnum.DRAFT.value:
-                self.instance.transition_draft()
+            if instance.state != Event.StateEnum.DRAFT.value:
+                instance.transition_draft()
+
+    def save(self):
+        instance = super().save()
+        self.save_state_transition(instance)
+        return instance
 
     def clean(self):
         data = super().clean()


### PR DESCRIPTION
closes #282

This commit moves the dashboard/forms handling of state transitions from the clean method,
into the save method. By doing so, FSM (and the related FSM logs) package have access to a saved DB
instance