### PR TITLE
Event Title and Description strings overflow on checkout portal if content is long enough

### DIFF
--- a/frontend/checkout-app/src/pages/Home/Home.tsx
+++ b/frontend/checkout-app/src/pages/Home/Home.tsx
@@ -223,7 +223,7 @@ export default function Home() {
                     role='alert'
                   >
                     <i className='fa-regular fa-times me-15'></i>
-                    <p className='m-0'>Sorry! Tickets are not available for this event?.</p>
+                    <p className='m-0'>Sorry! Tickets are not available for this event.</p>
                   </div>
                 </div>
               </>


### PR DESCRIPTION
# Issue [429-event-title-and-description-overflow-on-checkout-portal-if-string-is-long-enough](https://github.com/nftylabs/socialpass/issues/429)

The title and description of events were messing the event page on the checkout portal: `/:eventPublicId`

### Before: 
![image](https://user-images.githubusercontent.com/29418256/199268750-46703940-f615-4e90-8389-789b096991c6.png)



### After:
![image](https://user-images.githubusercontent.com/29418256/199268675-58ab8ea0-fcab-4f53-8afb-8507281c8075.png)
