### PR TITLE
Adding message to success enabling user to request tickets through Support Channel

### DIFF
--- a/frontend/checkout-app/src/pages/Success/Success.tsx
+++ b/frontend/checkout-app/src/pages/Success/Success.tsx
@@ -65,10 +65,10 @@ export default function Success() {
 
             <p className='text-muted fs-base-n2'>
             If you don't receive the tickets in your email in 10 minutes, please{' '}
-        <a href='https://nftyfinance.typeform.com/to/A70KW4vo' className='fw-bold' target='_blank' rel='noreferrer'>
-          click here to contact us
+        <a href='https://nftyfinance.typeform.com/to/A70KW4vo' className='fw-bold antialiased' target='_blank' rel='noreferrer'>
+          contact us
         </a>{' '}
-        informing this id:{' '}
+        and tell us this ID:{' '}
         <br></br>
         <strong>{checkout.public_id}</strong> 
 


### PR DESCRIPTION
Added a message to the checkout app success page instructing the user to identify himself through the checkout id in case he doesn't receive the ticket(s)

Closes #422 


Result: 
![image](https://user-images.githubusercontent.com/29418256/199270785-2954d031-e7da-4977-a13a-215c8093d597.png)
