### PR TITLE
Minor/scanner already redeemed toast

### DIFF
--- a/frontend/scanner-app/src/pages/Scanner/Scanner.tsx
+++ b/frontend/scanner-app/src/pages/Scanner/Scanner.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react'
 import { Html5QrcodeScanner } from './Html5QrcodeScanner'
-import toast from 'react-hot-toast'
+import { toast, Toaster } from 'react-hot-toast'
 import { FiAlertTriangle } from 'react-icons/fi'
 
 
@@ -35,7 +35,10 @@ const Scanner = () => {
         })
         .catch((err) => {
           if (err.message === 'Ticket has already been redeemed.')  {
-            toast.success(`Succesful Scan: ${err.message}`)
+            toast('Succesful Scan: Ticket has already been redeemed', {
+            icon: '⚠️',
+            });
+            
           }
           else  {
             toast.error(`Scan Failed: ${err.message}`)


### PR DESCRIPTION
Adds a custom Toast specifically for when the Scanner reads a ticket that has already been redeemed.
End result:
![image](https://user-images.githubusercontent.com/29418256/200823730-93b3603a-38d0-43f3-bf09-0abf33422d26.png)
