### PR TITLE
Adding warning toast to manual-redeem page

### DIFF
--- a/frontend/scanner-app/src/pages/ManualRedeem/ManualRedeem.tsx
+++ b/frontend/scanner-app/src/pages/ManualRedeem/ManualRedeem.tsx
@@ -34,7 +34,14 @@ const ManualRedeem = () => {
         toast.success(`Succesful Scan, Tier: ${data.ticket_tier.ticket_type}`)
       })
       .catch((err) => {
-        toast.error(`Scan Failed: ${err.message}`)
+        if (err.message === 'Ticket has already been redeemed.')  {
+          toast('Succesful Scan: Ticket has already been redeemed', {
+          icon: '⚠️',
+          });
+        }
+        else  {
+          toast.error(`Scan Failed: ${err.message}`)
+        }
       })
   }
 

--- a/frontend/scanner-app/src/pages/Scanner/Scanner.tsx
+++ b/frontend/scanner-app/src/pages/Scanner/Scanner.tsx
@@ -1,7 +1,6 @@
 import { useRef } from 'react'
 import { Html5QrcodeScanner } from './Html5QrcodeScanner'
-import { toast, Toaster } from 'react-hot-toast'
-import { FiAlertTriangle } from 'react-icons/fi'
+import { toast } from 'react-hot-toast'
 
 
 import useEvent from '@/hooks/useEvent'


### PR DESCRIPTION
Warning toast (for second or more redeeming try for the same ticket) was missing on the manual-redeem page.
This PR adds it.