### PR TITLE
minor/remove-linkedin-landing

### DIFF
--- a/backend/templates/event_discovery/base.html
+++ b/backend/templates/event_discovery/base.html
@@ -155,9 +155,9 @@
 									<i class="fa-brands fa-twitter"></i>
 									<span class="visually-hidden">Twitter</span>
 								</a>
-								<a href="https://www.linkedin.com/company/socialpass-io/" class="link-reset text-decoration-none" target="_blank" rel="noopener">
-									<i class="fa-brands fa-linkedin"></i>
-									<span class="visually-hidden">LinkedIn</span>
+								<a href="https://discord.gg/3jnCzESa" class="link-reset text-decoration-none" target="_blank" rel="noopener">
+									<i class="fa-brands fa-discord"></i>
+									<span class="visually-hidden">Discord</span>
 								</a>
 							</div>
 							<!-- Navbar links end -->
@@ -212,11 +212,11 @@
 										</a>
 									</div>
 									<div class="mt-10">
-										<a href="https://www.linkedin.com/company/socialpass-io/" target="_blank" class="d-inline-flex align-items-center link-reset text-decoration-none">
+										<a href="https://discord.gg/3jnCzESa" target="_blank" class="d-inline-flex align-items-center link-reset text-decoration-none">
 											<span class="ws-25">
-												<i class="fa-brands fa-linkedin"></i>
+												<i class="fa-brands fa-discord"></i>
 											</span>
-											<span>LinkedIn</span>
+											<span>Discord</span>
 										</a>
 									</div>
 								</div>


### PR DESCRIPTION
This PR replaces the LinkedIn link with Discord on the landing page (according to Marketing).