### PR TITLE
minor/payment-type-toggle-ui-improvements

### DIFF
--- a/frontend/checkout-app/src/pages/Home/Home.tsx
+++ b/frontend/checkout-app/src/pages/Home/Home.tsx
@@ -139,7 +139,7 @@ export default function Home() {
 
   const validateName = () => name.length > 0
 
-  //const eventHasTickets = () => ticketTiers.length
+  // const eventHasTickets = () => ticketTiers.length
 
   const handleGetTicketsButton = () => {
     saveCheckout().then((res) => {


### PR DESCRIPTION
This PR closes #584 

- Remove payment type toggles (for now, waste space and look bad if only one button)
- Bring out the ticket tiers from inside of `eventHasTickets` condition (they are disabled if no capacity)
- Add loading spinner for better UX