### PR TITLE
minor/vip-list-stats-on-scanner 

### DIFF
--- a/backend/apps/dashboard_organizer/views.py
+++ b/backend/apps/dashboard_organizer/views.py
@@ -1066,6 +1066,16 @@ class EventScannerStats(DetailView):
     def get(self, *args, **kwargs):
         self.object = self.get_object()
         context = super().get_context_data(**kwargs)
+
+        # VIP list
+        context["manual_attendees_total"] = ManualAttendee.objects.filter(
+            event=self.object,
+        ).count()
+        context["manual_attendees_redeemed"] = ManualAttendee.objects.filter(
+            event=self.object,
+            redeemed_at__isnull=False,
+        ).count()
+
         return render(
             self.request,
             template_name="redesign/scanner/scanner_stats.html",
@@ -1082,6 +1092,16 @@ class EventScanner2(DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update(dict(current_team=self.object.team))
+        
+        # VIP list
+        context["manual_attendees_total"] = ManualAttendee.objects.filter(
+            event=self.object,
+        ).count()
+        context["manual_attendees_redeemed"] = ManualAttendee.objects.filter(
+            event=self.object,
+            redeemed_at__isnull=False,
+        ).count()
+
         return context
 
     def post(self, *args, **kwargs):

--- a/backend/templates/redesign/scanner/scanner2.html
+++ b/backend/templates/redesign/scanner/scanner2.html
@@ -61,6 +61,20 @@
 					</div>
 				</div>
 			</div>
+			<hr />
+			<div class="h6">{% trans "VIP List" %}</div>
+			<div class="row mt-1">
+				<div class="col">
+					<div class="bg-primary-subtle text-primary-emphasis rounded-3 px-2 py-1 h-100">
+						<strong class="antialiased">{% trans "Total:" %} <br class="d-sm-none" />{{ manual_attendees_total }}</strong>
+					</div>
+				</div>
+				<div class="col">
+					<div class="bg-primary-subtle text-primary-emphasis rounded-3 px-2 py-1 h-100">
+						<strong class="antialiased">{% trans "Redeemed:" %} <br class="d-sm-none" />{{ manual_attendees_redeemed }}</strong>
+					</div>
+				</div>
+			</div>
 		</div>
 	</div>
 	<!-- HTMX Form -->

--- a/backend/templates/redesign/scanner/scanner_stats.html
+++ b/backend/templates/redesign/scanner/scanner_stats.html
@@ -15,3 +15,17 @@
 		</div>
 	</div>
 </div>
+<hr />
+<div class="h6">{% trans "VIP List" %}</div>
+<div class="row mt-2">
+	<div class="col">
+		<div class="bg-primary-subtle text-primary-emphasis rounded-3 px-2 py-1 h-100">
+			<strong class="antialiased">{% trans "Total:" %} <br class="d-sm-none" />{{ manual_attendees_total }}</strong>
+		</div>
+	</div>
+	<div class="col">
+		<div class="bg-primary-subtle text-primary-emphasis rounded-3 px-2 py-1 h-100">
+			<strong class="antialiased">{% trans "Redeemed:" %} <br class="d-sm-none" />{{ manual_attendees_redeemed }}</strong>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
This PR adds the VIP list stats on the scanner stats portion to make it less confusing for organizers if they choose to use the VIP list feature.

@crypto-rizzo One thing I noted though, the auto-stats reload via HTMX when a scan happens does not actually work. Could not figure out why, looks like the trigger is in the right place. Any insight/help on this would be amazing.

**EDIT**: Never mind, the HTMX reload works fine. I think the stats got cached for a while, so it looked like nothing updated. 