### PR TITLE
major/admin-performance

### DIFF
--- a/backend/apps/root/admin.py
+++ b/backend/apps/root/admin.py
@@ -35,7 +35,7 @@ class CustomDBAdmin(admin.ModelAdmin):
     list_display = ["public_id", "created", "modified"]
     sortable_by = ["public_id", "created", "modified"]
     ordering = ["-modified"]
-    list_per_page = 10
+    list_per_page = 1
 
 @admin.register(CheckoutItem)
 class CheckoutItemAdmin(CustomDBAdmin):
@@ -209,7 +209,6 @@ class TicketTierAdmin(CustomDBAdmin):
 
 @admin.register(Ticket)
 class TicketAdmin(CustomDBAdmin):
-    list_per_page = 5
     list_display = [
         "__str__",
         "event",


### PR DESCRIPTION
Our admin site is pretty badly optimized. This PR is an attempt to fix that. Please note, all of this is fairly simple stuff, so any feedback, or any pointers to better optimizations are more than welcome.

So using the admin for support, I think I've identified the most common issues:
- List views are very slow.
- By default, the Django admin allows any fields to be sorted by a click. This can produce unwanted results with a large dataset, where ordering on a non-indexed field might send a heavy query to the database, causing database pressure and the request timing out. If many admin users use sorting simultaneously it can cause cascading events, lowering the web servers and database performance. (Collected)
- The only tables we need to work with for support are `Event`, `CheckoutSession`, and `Ticket`. That covers ~98% of our cases.

Implemented solutions:
- Limit object per page to 20 on list views. We have search for every relevant table, so we should definitely use that more as an average search should return only a handful of objects. I would honestly be open to reducing this to 10 (instead of 20).
- Sorting only allowed on `created`, `modified`, and `public_id` for all tables.
- The `Ticket` list view is the worst offender from my experience. I've limited this one to 5 items per page, and added in search using name, email, or event title.
- We're already doing `select_related` for all relevant foreign keys.

Once again, feedback always welcome. As well as any possible query optimizations.