### PR TITLE
bugfix/team-event-unique-constraint-form

### DIFF
--- a/backend/apps/dashboard_organizer/forms.py
+++ b/backend/apps/dashboard_organizer/forms.py
@@ -78,6 +78,7 @@ class EventCreateForm(forms.ModelForm):
     class Meta:
         model = Event
         fields = [
+            "team",
             "title",
             "description",
             "cover_image",
@@ -125,6 +126,7 @@ class EventForm(forms.ModelForm):
     class Meta:
         model = Event
         fields = [
+            "team",
             "title",
             "description",
             "cover_image",

--- a/backend/apps/dashboard_organizer/views.py
+++ b/backend/apps/dashboard_organizer/views.py
@@ -399,7 +399,13 @@ class EventCreateView(SuccessMessageMixin, TeamContextMixin, CreateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["GMAPS_API_KEY"] = settings.GMAPS_API_KEY
+        self.initial["team"] = context["current_team"].pk
         return context
+
+    def get_initial(self):
+        initial = super().get_initial()
+        initial["team"] = self.team
+        return initial
 
     def form_valid(self, form, **kwargs):
         context = self.get_context_data(**kwargs)

--- a/backend/templates/redesign/dashboard_organizer/event_create.html
+++ b/backend/templates/redesign/dashboard_organizer/event_create.html
@@ -40,6 +40,7 @@
 				{% for input in form.hidden_fields %}
 					{{ input }}
 				{% endfor %}
+				<div>{{ form.team.as_hidden }}</div>
 				<div class="mb-1">
 					{% with form.title as input %}
 						<input

--- a/backend/templates/redesign/dashboard_organizer/event_form.html
+++ b/backend/templates/redesign/dashboard_organizer/event_form.html
@@ -36,6 +36,8 @@
 						{{ input }}
 					{% endfor %}
 
+					<div>{{ form.team.as_hidden }}</div>
+
 					<h4 class="mb-lg-4">{% trans "Banner, Title, and Description" %}</h4>
 					<div class="row g-4">
 						<div class="col-md-6">


### PR DESCRIPTION
Closes #988 

An easy way to fix #988 would be adding in the `team` field to the event forms, and let Django's default validation do the rest. This PR does exactly that:

- The `team` is a hidden field with an initial value set to the current team.
- It's hidden so users won't be able to change it.
- If they use inspect element to try and break the system, the line `form.instance.team = context["current_team"]` in the `form_valid(...)` function would override this attempt. 

![Screen Shot 2024-01-24 at 4 29 19 PM](https://github.com/SPTech-Group/socialpass/assets/67643916/00d31835-35ff-4ade-9663-1c0912abe823)
