### PR TITLE
refactor/attendee-messaging-mass

### DIFF
--- a/backend/apps/root/models.py
+++ b/backend/apps/root/models.py
@@ -12,7 +12,7 @@ from django.contrib.auth.models import AbstractUser
 from django.contrib.postgres.fields import ArrayField
 from django.contrib.sites.models import Site
 from django.contrib.staticfiles.storage import staticfiles_storage
-from django.core.mail import send_mail
+from django.core.mail import send_mail, send_mass_mail
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.db.models import Q, Count, F
@@ -1769,16 +1769,15 @@ class MessageBatch(DBModel):
         emails = list(set(emails))
         self.total_recipients = len(emails)
 
-        # Send emails individually
-        # TODO: Look into send_mass_mail(), 
-        # even though it does not support HTML natively
-        for email in emails:
-            send_mail(
-                "[SocialPass] " + self.subject,
-                self.message,
-                "tickets-no-reply@socialpass.io",
-                [email,]
-            )
+        # Send mass emails
+        # This function opens a connection to the mail server only once
+        messages = [(
+            "[SocialPass] " + self.subject,
+            self.message,
+            "tickets-no-reply@socialpass.io",
+            [email]
+        ) for email in emails]
+        send_mass_mail(messages)
 
 
 class ManualAttendee(DBModel):


### PR DESCRIPTION
Closes #1058 

This PR changes `send_mail` to `send_mass_mail`, which opens a connection to the email server only once, making it more performant. We don't need BCCs here, the emails are being sent to different addresses because that's how `send_mass_mail` works. 

![Screen Shot 2024-02-29 at 2 41 41 PM](https://github.com/SPTech-Group/socialpass/assets/67643916/b7912910-ea56-4fac-8352-3110a41dbe37)

Anyway, I think this is a good patch to have only in the short-run. In the long-run, I would like to do this entirely via the API of our mail provider. For example, we gather all the emails and just send a POST request to the mail server and forget about it, the mail server would take the emails and send the bulk email to everyone individually (or via BCCs). This is not supported by Mailgun from my initial finding, they don't have an endpoint for bulk emails unfortunately. I've opened up another issue to track this: https://github.com/SPTech-Group/socialpass/issues/1071